### PR TITLE
Add missing link to list manipulation documentation

### DIFF
--- a/packages/beta-docs/pages/core/working-memory.mdx
+++ b/packages/beta-docs/pages/core/working-memory.mdx
@@ -53,7 +53,7 @@ const withHi = memory.withMemory({
 const withoutHi = withHi.slice(0,1)
 ```
 
-There are many list manipulation functions available to you, read more... [todo: add link].
+There are many list manipulation functions available to you, read more in the [list manipulation documentation](./list-manipulation).
 
 ## Example Cognitive Steps
 


### PR DESCRIPTION
## Summary
This PR addresses an incomplete TODO in the working-memory.mdx documentation by adding the missing link to the list manipulation documentation.

**Changes:**
- Replaced `[todo: add link]` with actual link to `./list-manipulation` page
- Improved sentence clarity

The list-manipulation.mdx file exists and contains the relevant documentation, so this simply connects the documentation properly.

Generated with Claude Code (https://claude.com/claude-code)